### PR TITLE
Add multiple authors support for tools

### DIFF
--- a/data/tools/intune-monitoring.json
+++ b/data/tools/intune-monitoring.json
@@ -14,11 +14,27 @@
     "visualization",
     "os updates"
   ],
-  "author": "Daniel Rung & Ugur Koc",
-  "authorPicture": "https://github.com/ugurkocde.png",
-  "githubUrl": "https://github.com/ugurkocde",
-  "linkedinUrl": "https://www.linkedin.com/in/ugurkocde/",
-  "xUrl": "https://x.com/UgurKocDe",
+  "author": "Daniel Rung",
+  "authorPicture": "https://github.com/danrung.png",
+  "githubUrl": "https://github.com/danrung",
+  "linkedinUrl": "",
+  "xUrl": "",
+  "authors": [
+    {
+      "name": "Daniel Rung",
+      "picture": "https://github.com/danrung.png",
+      "githubUrl": "https://github.com/danrung",
+      "linkedinUrl": "",
+      "xUrl": ""
+    },
+    {
+      "name": "Ugur Koc",
+      "picture": "https://github.com/ugurkocde.png",
+      "githubUrl": "https://github.com/ugurkocde",
+      "linkedinUrl": "https://www.linkedin.com/in/ugurkocde/",
+      "xUrl": "https://x.com/UgurKocDe"
+    }
+  ],
   "repoUrl": "https://github.com/ugurkocde/IntuneMonitoring",
   "downloadUrl": "",
   "websiteUrl": "https://www.intunemonitoring.com/",

--- a/src/app/tools/[id]/page.tsx
+++ b/src/app/tools/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
 import { getToolById, getAllToolIds } from "~/lib/tools.server";
+import { getToolAuthors } from "~/lib/tools";
 import { TYPE_CONFIG, CATEGORY_CONFIG, SITE_CONFIG } from "~/lib/constants";
 import {
   generateToolStructuredData,
@@ -240,119 +241,129 @@ export default async function ToolPage({ params }: ToolPageProps) {
                 {tool.description}
               </p>
 
-              {/* Author Section */}
-              <div
-                className="mt-10 flex flex-col gap-6 border-t pt-8 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between"
-                style={{ borderColor: "rgba(255, 255, 255, 0.06)" }}
-              >
-                {/* Author Info Row */}
-                <div className="flex items-center gap-4">
-                  {/* Avatar */}
+              {/* Authors Section */}
+              {(() => {
+                const authors = getToolAuthors(tool);
+                return (
                   <div
-                    className="flex h-14 w-14 flex-shrink-0 items-center justify-center overflow-hidden rounded-full"
-                    style={{
-                      background: tool.authorPicture
-                        ? "transparent"
-                        : `linear-gradient(135deg, ${categoryConfig.color}50, ${categoryConfig.color}25)`,
-                      border: `2px solid ${categoryConfig.color}40`,
-                      boxShadow: `0 0 20px ${categoryConfig.color}15`,
-                    }}
+                    className="mt-10 border-t pt-8"
+                    style={{ borderColor: "rgba(255, 255, 255, 0.06)" }}
                   >
-                    {tool.authorPicture ? (
-                      <Image
-                        src={tool.authorPicture}
-                        alt={tool.author}
-                        width={56}
-                        height={56}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      <span
-                        className="text-xl font-bold"
-                        style={{ color: categoryConfig.color }}
-                      >
-                        {tool.author.charAt(0).toUpperCase()}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Author Name */}
-                  <div className="flex flex-col">
                     <span
-                      className="text-sm uppercase tracking-wider"
+                      className="mb-4 block text-sm uppercase tracking-wider"
                       style={{ color: "var(--text-tertiary)" }}
                     >
                       Created by
                     </span>
-                    <span
-                      className="text-lg font-semibold"
-                      style={{ color: "var(--text-primary)" }}
-                    >
-                      {tool.author}
-                    </span>
-                  </div>
-                </div>
+                    <div className={`flex flex-wrap gap-6 ${authors.length > 1 ? "flex-col sm:flex-row" : ""}`}>
+                      {authors.map((author, index) => (
+                        <div
+                          key={`${author.name}-${index}`}
+                          className="flex items-center gap-4"
+                        >
+                          {/* Avatar */}
+                          <div
+                            className="flex h-14 w-14 flex-shrink-0 items-center justify-center overflow-hidden rounded-full"
+                            style={{
+                              background: author.picture
+                                ? "transparent"
+                                : `linear-gradient(135deg, ${categoryConfig.color}50, ${categoryConfig.color}25)`,
+                              border: `2px solid ${categoryConfig.color}40`,
+                              boxShadow: `0 0 20px ${categoryConfig.color}15`,
+                            }}
+                          >
+                            {author.picture ? (
+                              <Image
+                                src={author.picture}
+                                alt={author.name}
+                                width={56}
+                                height={56}
+                                className="h-full w-full object-cover"
+                              />
+                            ) : (
+                              <span
+                                className="text-xl font-bold"
+                                style={{ color: categoryConfig.color }}
+                              >
+                                {author.name.charAt(0).toUpperCase()}
+                              </span>
+                            )}
+                          </div>
 
-                {/* Social Links */}
-                {[tool.githubUrl, tool.linkedinUrl, tool.xUrl].some(Boolean) && (
-                  <div className="flex items-center gap-2">
-                    {tool.githubUrl && (
-                      <a
-                        href={tool.githubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex h-10 w-10 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
-                        style={{
-                          background: "rgba(255, 255, 255, 0.04)",
-                          border: "1px solid rgba(255, 255, 255, 0.08)",
-                          color: "var(--text-secondary)",
-                        }}
-                        title="GitHub Profile"
-                      >
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                        </svg>
-                      </a>
-                    )}
-                    {tool.linkedinUrl && (
-                      <a
-                        href={tool.linkedinUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex h-10 w-10 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
-                        style={{
-                          background: "rgba(255, 255, 255, 0.04)",
-                          border: "1px solid rgba(255, 255, 255, 0.08)",
-                          color: "var(--text-secondary)",
-                        }}
-                        title="LinkedIn Profile"
-                      >
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                        </svg>
-                      </a>
-                    )}
-                    {tool.xUrl && (
-                      <a
-                        href={tool.xUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex h-10 w-10 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
-                        style={{
-                          background: "rgba(255, 255, 255, 0.04)",
-                          border: "1px solid rgba(255, 255, 255, 0.08)",
-                          color: "var(--text-secondary)",
-                        }}
-                        title="X (Twitter) Profile"
-                      >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                        </svg>
-                      </a>
-                    )}
+                          {/* Author Name and Social Links */}
+                          <div className="flex flex-col gap-2">
+                            <span
+                              className="text-lg font-semibold"
+                              style={{ color: "var(--text-primary)" }}
+                            >
+                              {author.name}
+                            </span>
+                            {/* Social Links */}
+                            {[author.githubUrl, author.linkedinUrl, author.xUrl].some(Boolean) && (
+                              <div className="flex items-center gap-2">
+                                {author.githubUrl && (
+                                  <a
+                                    href={author.githubUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex h-8 w-8 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
+                                    style={{
+                                      background: "rgba(255, 255, 255, 0.04)",
+                                      border: "1px solid rgba(255, 255, 255, 0.08)",
+                                      color: "var(--text-secondary)",
+                                    }}
+                                    title="GitHub Profile"
+                                  >
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                                    </svg>
+                                  </a>
+                                )}
+                                {author.linkedinUrl && (
+                                  <a
+                                    href={author.linkedinUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex h-8 w-8 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
+                                    style={{
+                                      background: "rgba(255, 255, 255, 0.04)",
+                                      border: "1px solid rgba(255, 255, 255, 0.08)",
+                                      color: "var(--text-secondary)",
+                                    }}
+                                    title="LinkedIn Profile"
+                                  >
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                                    </svg>
+                                  </a>
+                                )}
+                                {author.xUrl && (
+                                  <a
+                                    href={author.xUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex h-8 w-8 items-center justify-center rounded-lg transition-all hover:scale-105 hover:border-white/20 hover:bg-white/10 hover:text-[var(--text-primary)]"
+                                    style={{
+                                      background: "rgba(255, 255, 255, 0.04)",
+                                      border: "1px solid rgba(255, 255, 255, 0.08)",
+                                      color: "var(--text-secondary)",
+                                    }}
+                                    title="X (Twitter) Profile"
+                                  >
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                                      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                                    </svg>
+                                  </a>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                )}
-              </div>
+                );
+              })()}
 
               {/* Action Buttons - Only show if at least one URL exists */}
               {[tool.repoUrl, tool.downloadUrl, tool.websiteUrl].some(Boolean) && (

--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import type { Tool } from "~/types/tool";
 import { TYPE_CONFIG, CATEGORY_CONFIG } from "~/lib/constants";
 import { trackToolClick, trackOutboundLink } from "~/lib/plausible";
+import { getToolAuthors } from "~/lib/tools";
 import { formatViewCount } from "~/hooks/useViewTracking";
 
 interface ToolCardProps {
@@ -260,58 +261,91 @@ export const ToolCard = memo(function ToolCard({
               </div>
             )}
 
-            {/* Author */}
-            <div className="mt-5 flex items-center gap-3">
-              <div
-                className="flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-bold transition-transform duration-200 group-hover:scale-110"
-                style={{
-                  background: tool.authorPicture
-                    ? "transparent"
-                    : `linear-gradient(135deg, ${categoryConfig.color}40, ${categoryConfig.color}20)`,
-                  color: categoryConfig.color,
-                  border: `1px solid ${categoryConfig.color}30`,
-                }}
-              >
-                {tool.authorPicture ? (
-                  <Image
-                    src={tool.authorPicture}
-                    alt={tool.author}
-                    width={32}
-                    height={32}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  tool.author.charAt(0).toUpperCase()
-                )}
-              </div>
-              <div>
-                {tool.githubUrl ? (
-                  <a
-                    href={tool.githubUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="text-sm font-medium transition-colors hover:text-[var(--accent-primary)]"
-                    style={{ color: "var(--text-primary)" }}
-                  >
-                    {tool.author}
-                  </a>
-                ) : (
-                  <span
-                    className="text-sm font-medium"
-                    style={{ color: "var(--text-primary)" }}
-                  >
-                    {tool.author}
-                  </span>
-                )}
-                <div
-                  className="text-xs"
-                  style={{ color: "var(--text-tertiary)" }}
-                >
-                  {categoryConfig.label}
+            {/* Authors */}
+            {(() => {
+              const authors = getToolAuthors(tool);
+              const maxVisible = 3;
+              const visibleAuthors = authors.slice(0, maxVisible);
+              const remainingCount = authors.length - maxVisible;
+
+              return (
+                <div className="mt-5 flex items-center gap-3">
+                  {/* Stacked Avatars */}
+                  <div className="flex -space-x-2">
+                    {visibleAuthors.map((author, idx) => (
+                      <div
+                        key={`${author.name}-${idx}`}
+                        className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-bold ring-2 ring-[#111922] transition-transform duration-200 group-hover:scale-110"
+                        style={{
+                          background: author.picture
+                            ? "transparent"
+                            : `linear-gradient(135deg, ${categoryConfig.color}40, ${categoryConfig.color}20)`,
+                          color: categoryConfig.color,
+                          border: `1px solid ${categoryConfig.color}30`,
+                          zIndex: visibleAuthors.length - idx,
+                        }}
+                      >
+                        {author.picture ? (
+                          <Image
+                            src={author.picture}
+                            alt={author.name}
+                            width={32}
+                            height={32}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          author.name.charAt(0).toUpperCase()
+                        )}
+                      </div>
+                    ))}
+                    {remainingCount > 0 && (
+                      <div
+                        className="relative flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-bold ring-2 ring-[#111922]"
+                        style={{
+                          background: `linear-gradient(135deg, ${categoryConfig.color}40, ${categoryConfig.color}20)`,
+                          color: categoryConfig.color,
+                          border: `1px solid ${categoryConfig.color}30`,
+                          zIndex: 0,
+                        }}
+                      >
+                        +{remainingCount}
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    {authors.length === 1 && authors[0]?.githubUrl ? (
+                      <a
+                        href={authors[0].githubUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-sm font-medium transition-colors hover:text-[var(--accent-primary)]"
+                        style={{ color: "var(--text-primary)" }}
+                      >
+                        {authors[0].name}
+                      </a>
+                    ) : (
+                      <span
+                        className="text-sm font-medium"
+                        style={{ color: "var(--text-primary)" }}
+                      >
+                        {authors.length === 1
+                          ? authors[0]?.name
+                          : authors.length === 2
+                            ? `${authors[0]?.name} & ${authors[1]?.name}`
+                            : `${authors[0]?.name} & ${authors.length - 1} others`}
+                      </span>
+                    )}
+                    <div
+                      className="text-xs"
+                      style={{ color: "var(--text-tertiary)" }}
+                    >
+                      {categoryConfig.label}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
+              );
+            })()}
 
             {/* Action Links */}
             <div

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -19,8 +19,20 @@ export async function createToolSubmissionIssue(
   const categoryLabel = CATEGORY_CONFIG[data.category].label;
   const typeLabel = TYPE_CONFIG[data.type].label;
 
-  // Derive avatar URL from GitHub profile if provided
-  const avatarUrl = data.githubUrl ? deriveAvatarUrl(data.githubUrl) : null;
+  // Format authors section
+  const authorsSection = data.authors
+    .map((author, index) => {
+      const avatarUrl = author.githubUrl ? deriveAvatarUrl(author.githubUrl) : null;
+      const lines = [
+        `#### Author ${index + 1}: ${author.name}`,
+        author.githubUrl ? `- **GitHub:** ${author.githubUrl}` : "",
+        avatarUrl ? `- **Avatar:** ${avatarUrl}` : "",
+        author.linkedinUrl ? `- **LinkedIn:** ${author.linkedinUrl}` : "",
+        author.xUrl ? `- **X/Twitter:** ${author.xUrl}` : "",
+      ].filter(Boolean);
+      return lines.join("\n");
+    })
+    .join("\n\n");
 
   // Build issue body in a structured format
   const body = `## Tool Submission
@@ -28,16 +40,12 @@ export async function createToolSubmissionIssue(
 ### Tool Information
 - **Name:** ${data.name}
 - **Description:** ${data.description}
-- **Author:** ${data.author}
 - **Repository URL:** ${data.repoUrl}
 - **Category:** ${categoryLabel}
 - **Type:** ${typeLabel}
 
-### Author Links
-${data.githubUrl ? `- **GitHub:** ${data.githubUrl}` : "- **GitHub:** Not provided"}
-${avatarUrl ? `- **Avatar:** ${avatarUrl}` : ""}
-${data.linkedinUrl ? `- **LinkedIn:** ${data.linkedinUrl}` : ""}
-${data.xUrl ? `- **X/Twitter:** ${data.xUrl}` : ""}
+### Authors
+${authorsSection}
 
 ### Optional URLs
 ${data.downloadUrl ? `- **Download URL:** ${data.downloadUrl}` : ""}

--- a/src/lib/schemas/tool-submission.ts
+++ b/src/lib/schemas/tool-submission.ts
@@ -24,27 +24,12 @@ const VALID_TYPES = [
   "other",
 ] as const;
 
-export const toolSubmissionSchema = z.object({
-  // Required fields
+// Author schema for multiple authors support
+const authorSchema = z.object({
   name: z
-    .string()
-    .min(2, "Tool name must be at least 2 characters")
-    .max(100, "Tool name must be less than 100 characters"),
-  description: z
-    .string()
-    .min(20, "Description must be at least 20 characters")
-    .max(500, "Description must be less than 500 characters"),
-  author: z
     .string()
     .min(2, "Author name must be at least 2 characters")
     .max(50, "Author name must be less than 50 characters"),
-  repoUrl: z
-    .string()
-    .url("Please enter a valid URL"),
-  category: z.enum(VALID_CATEGORIES),
-  type: z.enum(VALID_TYPES),
-
-  // Optional author links (collapsible section)
   githubUrl: z
     .string()
     .url("Must be a valid URL")
@@ -72,6 +57,29 @@ export const toolSubmissionSchema = z.object({
     )
     .optional()
     .or(z.literal("")),
+});
+
+export type SubmissionAuthor = z.infer<typeof authorSchema>;
+
+export const toolSubmissionSchema = z.object({
+  // Required fields
+  name: z
+    .string()
+    .min(2, "Tool name must be at least 2 characters")
+    .max(100, "Tool name must be less than 100 characters"),
+  description: z
+    .string()
+    .min(20, "Description must be at least 20 characters")
+    .max(500, "Description must be less than 500 characters"),
+  authors: z
+    .array(authorSchema)
+    .min(1, "At least one author is required")
+    .max(5, "Maximum 5 authors allowed"),
+  repoUrl: z
+    .string()
+    .url("Please enter a valid URL"),
+  category: z.enum(VALID_CATEGORIES),
+  type: z.enum(VALID_TYPES),
 
   // Optional tool links
   downloadUrl: z.string().url("Must be a valid URL").optional().or(z.literal("")),

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,20 +1,23 @@
 import type { Tool } from "~/types/tool";
 import { SITE_CONFIG, CATEGORY_CONFIG } from "./constants";
+import { getToolAuthors } from "./tools";
 
 /**
  * Generate JSON-LD structured data for a tool (SoftwareApplication schema)
  */
 export function generateToolStructuredData(tool: Tool) {
+  const authors = getToolAuthors(tool);
+
   return {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     name: tool.name,
     description: tool.description,
-    author: {
+    author: authors.map((author) => ({
       "@type": "Person",
-      name: tool.author,
-      ...(tool.githubUrl && { url: tool.githubUrl }),
-    },
+      name: author.name,
+      ...(author.githubUrl && { url: author.githubUrl }),
+    })),
     applicationCategory: CATEGORY_CONFIG[tool.category]?.label ?? tool.category,
     operatingSystem: getOperatingSystem(tool.type),
     ...(tool.repoUrl && { codeRepository: tool.repoUrl }),

--- a/src/lib/tools.server.ts
+++ b/src/lib/tools.server.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import type { Tool } from "~/types/tool";
+import { getToolAuthors } from "./tools";
 
 const TOOLS_DIRECTORY = path.join(process.cwd(), "data", "tools");
 
@@ -36,11 +37,14 @@ export function getAllTools(): Tool[] {
 }
 
 /**
- * Get unique authors count
+ * Get unique authors count (counts all authors from multi-author tools)
  */
 export function getUniqueAuthorsCount(tools: Tool[]): number {
   const authors = new Set<string>();
-  tools.forEach((tool) => authors.add(tool.author.toLowerCase()));
+  tools.forEach((tool) => {
+    const toolAuthors = getToolAuthors(tool);
+    toolAuthors.forEach((author) => authors.add(author.name.toLowerCase()));
+  });
   return authors.size;
 }
 

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,4 +1,24 @@
-import type { Tool, ToolCategory, ToolType } from "~/types/tool";
+import type { Author, Tool, ToolCategory, ToolType } from "~/types/tool";
+
+/**
+ * Get normalized authors array from a tool.
+ * Handles both legacy single-author fields and new authors array.
+ */
+export function getToolAuthors(tool: Tool): Author[] {
+  if (tool.authors && tool.authors.length > 0) {
+    return tool.authors;
+  }
+
+  return [
+    {
+      name: tool.author,
+      picture: tool.authorPicture,
+      githubUrl: tool.githubUrl,
+      linkedinUrl: tool.linkedinUrl,
+      xUrl: tool.xUrl,
+    },
+  ];
+}
 
 /**
  * Get tools filtered by category
@@ -18,7 +38,7 @@ export function getToolsByType(tools: Tool[], type: ToolType): Tool[] {
 }
 
 /**
- * Search tools by query (searches name, description, and author)
+ * Search tools by query (searches name, description, and all authors)
  */
 export function searchTools(tools: Tool[], query: string): Tool[] {
   const normalizedQuery = query.toLowerCase().trim();
@@ -26,7 +46,9 @@ export function searchTools(tools: Tool[], query: string): Tool[] {
   if (!normalizedQuery) return tools;
 
   return tools.filter((tool) => {
-    const searchableText = [tool.name, tool.description, tool.author]
+    const authors = getToolAuthors(tool);
+    const authorNames = authors.map((a) => a.name).join(" ");
+    const searchableText = [tool.name, tool.description, authorNames]
       .join(" ")
       .toLowerCase();
 

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -20,6 +20,14 @@ export type ToolType =
   | "documentation"
   | "other";
 
+export interface Author {
+  name: string;
+  picture?: string;
+  githubUrl?: string;
+  linkedinUrl?: string;
+  xUrl?: string;
+}
+
 export interface Tool {
   id: string;
   name: string;
@@ -30,6 +38,7 @@ export interface Tool {
   githubUrl?: string;
   linkedinUrl?: string;
   xUrl?: string;
+  authors?: Author[];
   repoUrl?: string;
   downloadUrl?: string;
   websiteUrl?: string;


### PR DESCRIPTION
## Summary
- Add support for tools with multiple authors, each with their own profile (avatar, GitHub, LinkedIn, X links)
- Maintain backward compatibility with existing single-author tools
- Display stacked avatars on tool cards
- Show all authors with individual profiles on tool detail pages
- Update submission form to allow adding/removing up to 5 authors

## Changes
- Add `Author` interface and `authors` array to Tool type
- Add `getToolAuthors()` helper for normalizing author data
- Update ToolCard with stacked avatars UI
- Update ToolPage with multi-author display
- Update ToolSubmitForm for multiple author input
- Update Zod schema, GitHub issue creation, and structured data
- Update intune-monitoring.json as example with multiple authors

## Test plan
- [ ] Verify tools with single author display correctly (backward compatibility)
- [ ] Verify tools with multiple authors show stacked avatars on cards
- [ ] Verify tool detail pages show all authors with their profiles
- [ ] Test the submit form with multiple authors
- [ ] Verify search works across all author names