### PR TITLE
Add GitHub links to security check line numbers

### DIFF
--- a/.github/workflows/approve-tool-submission.yml
+++ b/.github/workflows/approve-tool-submission.yml
@@ -264,7 +264,7 @@ jobs:
               return { files, branch: usedBranch };
             }
 
-            function runPatternChecks(files) {
+            function runPatternChecks(files, repoInfo = {}) {
               const results = {
                 noObfuscatedCode: { passed: true, reason: '', details: [] },
                 noRemoteExecution: { passed: true, reason: '', details: [] },
@@ -292,6 +292,17 @@ jobs:
                 });
 
                 return lineNumbers;
+              };
+
+              // Helper to generate GitHub URL with line anchor
+              const generateGitHubLink = (filePath, lineNumbers) => {
+                if (!repoInfo.owner || !repoInfo.repo || !repoInfo.branch || lineNumbers.length === 0) {
+                  return null;
+                }
+                const firstLine = lineNumbers[0];
+                const lastLine = lineNumbers.length > 1 ? lineNumbers[Math.min(lineNumbers.length - 1, 4)] : firstLine;
+                const lineAnchor = firstLine === lastLine ? '#L' + firstLine : '#L' + firstLine + '-L' + lastLine;
+                return 'https://github.com/' + repoInfo.owner + '/' + repoInfo.repo + '/blob/' + repoInfo.branch + '/' + filePath + lineAnchor;
               };
 
               // Pattern definitions as strings to avoid regex state issues
@@ -361,12 +372,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noObfuscatedCode.passed = false;
-                    results.noObfuscatedCode.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noObfuscatedCode.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noObfuscatedCode.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noObfuscatedCode.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noObfuscatedCode.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noObfuscatedCode.githubLink = githubLink;
                     }
                   }
                 }
@@ -375,12 +388,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noRemoteExecution.passed = false;
-                    results.noRemoteExecution.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noRemoteExecution.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noRemoteExecution.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noRemoteExecution.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noRemoteExecution.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noRemoteExecution.githubLink = githubLink;
                     }
                   }
                 }
@@ -389,12 +404,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern, 'i');
                   if (lineNumbers.length > 0) {
                     results.noCredentialTheft.passed = false;
-                    results.noCredentialTheft.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noCredentialTheft.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noCredentialTheft.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noCredentialTheft.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noCredentialTheft.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noCredentialTheft.githubLink = githubLink;
                     }
                   }
                 }
@@ -403,12 +420,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noDataExfiltration.passed = false;
-                    results.noDataExfiltration.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noDataExfiltration.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noDataExfiltration.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noDataExfiltration.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noDataExfiltration.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noDataExfiltration.githubLink = githubLink;
                     }
                   }
                 }
@@ -417,12 +436,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noMaliciousPatterns.passed = false;
-                    results.noMaliciousPatterns.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noMaliciousPatterns.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noMaliciousPatterns.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noMaliciousPatterns.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noMaliciousPatterns.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noMaliciousPatterns.githubLink = githubLink;
                     }
                   }
                 }
@@ -431,12 +452,14 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noHardcodedSecrets.passed = false;
-                    results.noHardcodedSecrets.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers });
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
+                    results.noHardcodedSecrets.details.push({ file: file.path, pattern: p.desc, lines: lineNumbers, githubLink });
                     if (!results.noHardcodedSecrets.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noHardcodedSecrets.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noHardcodedSecrets.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noHardcodedSecrets.githubLink = githubLink;
                     }
                   }
                 }
@@ -499,6 +522,14 @@ jobs:
             async function performSecurityScan(repoUrl, toolNameForScan) {
               console.log('Starting security scan for: ' + repoUrl);
 
+              // Extract owner and repo from URL for GitHub links
+              const repoMatch = repoUrl.match(/github\.com\/([^/]+)\/([^/]+)/);
+              const repoInfo = repoMatch ? {
+                owner: repoMatch[1],
+                repo: repoMatch[2].replace(/\.git$/, ''),
+                branch: null // Will be set after fetching files
+              } : {};
+
               // Fetch repository metadata
               const repoMeta = await fetchRepoMetadata(repoUrl);
               if (repoMeta) {
@@ -507,6 +538,7 @@ jobs:
 
               // Fetch files from repo
               const { files, branch } = await fetchRepoFiles(repoUrl);
+              repoInfo.branch = branch; // Set the branch for GitHub links
               console.log('Scanned ' + files.length + ' files from branch: ' + branch);
 
               if (files.length === 0) {
@@ -529,7 +561,7 @@ jobs:
               }
 
               // Run pattern-based checks
-              const patternResults = runPatternChecks(files);
+              const patternResults = runPatternChecks(files, repoInfo);
 
               // Run AI analysis for additional context
               const aiResults = await runAISecurityCheck(files, toolNameForScan);

--- a/.github/workflows/backfill-security-scans.yml
+++ b/.github/workflows/backfill-security-scans.yml
@@ -164,7 +164,7 @@ jobs:
               return { files, branch: usedBranch };
             }
 
-            function runPatternChecks(files) {
+            function runPatternChecks(files, repoInfo = {}) {
               const results = {
                 noObfuscatedCode: { passed: true, reason: '', details: [] },
                 noRemoteExecution: { passed: true, reason: '', details: [] },
@@ -191,6 +191,17 @@ jobs:
                 });
 
                 return lineNumbers;
+              };
+
+              // Helper to generate GitHub URL with line anchor
+              const generateGitHubLink = (filePath, lineNumbers) => {
+                if (!repoInfo.owner || !repoInfo.repo || !repoInfo.branch || lineNumbers.length === 0) {
+                  return null;
+                }
+                const firstLine = lineNumbers[0];
+                const lastLine = lineNumbers.length > 1 ? lineNumbers[Math.min(lineNumbers.length - 1, 4)] : firstLine;
+                const lineAnchor = firstLine === lastLine ? '#L' + firstLine : '#L' + firstLine + '-L' + lastLine;
+                return 'https://github.com/' + repoInfo.owner + '/' + repoInfo.repo + '/blob/' + repoInfo.branch + '/' + filePath + lineAnchor;
               };
 
               const patterns = {
@@ -242,11 +253,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noObfuscatedCode.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noObfuscatedCode.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noObfuscatedCode.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noObfuscatedCode.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noObfuscatedCode.githubLink = githubLink;
                     }
                   }
                 }
@@ -255,11 +268,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noRemoteExecution.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noRemoteExecution.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noRemoteExecution.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noRemoteExecution.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noRemoteExecution.githubLink = githubLink;
                     }
                   }
                 }
@@ -268,11 +283,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern, 'i');
                   if (lineNumbers.length > 0) {
                     results.noCredentialTheft.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noCredentialTheft.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noCredentialTheft.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noCredentialTheft.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noCredentialTheft.githubLink = githubLink;
                     }
                   }
                 }
@@ -281,11 +298,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noDataExfiltration.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noDataExfiltration.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noDataExfiltration.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noDataExfiltration.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noDataExfiltration.githubLink = githubLink;
                     }
                   }
                 }
@@ -294,11 +313,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noMaliciousPatterns.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noMaliciousPatterns.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noMaliciousPatterns.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noMaliciousPatterns.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noMaliciousPatterns.githubLink = githubLink;
                     }
                   }
                 }
@@ -307,11 +328,13 @@ jobs:
                   const lineNumbers = findLineNumbers(content, p.pattern);
                   if (lineNumbers.length > 0) {
                     results.noHardcodedSecrets.passed = false;
+                    const githubLink = generateGitHubLink(file.path, lineNumbers);
                     if (!results.noHardcodedSecrets.reason) {
                       const lineInfo = lineNumbers.length <= 5
                         ? lineNumbers.join(', ')
                         : lineNumbers.slice(0, 5).join(', ') + '...';
-                      results.noHardcodedSecrets.reason = p.desc + ' in ' + file.path + ' (lines: ' + lineInfo + ')';
+                      results.noHardcodedSecrets.reason = p.desc + ' in ' + file.path + ' ([lines: ' + lineInfo + '](' + (githubLink || '#') + '))';
+                      results.noHardcodedSecrets.githubLink = githubLink;
                     }
                   }
                 }
@@ -370,8 +393,17 @@ jobs:
             }
 
             async function performSecurityScan(repoUrl, toolName) {
+              // Extract owner and repo from URL for GitHub links
+              const repoMatch = repoUrl.match(/github\.com\/([^/]+)\/([^/]+)/);
+              const repoInfo = repoMatch ? {
+                owner: repoMatch[1],
+                repo: repoMatch[2].replace(/\.git$/, ''),
+                branch: null // Will be set after fetching files
+              } : {};
+
               const repoMeta = await fetchRepoMetadata(repoUrl);
               const { files, branch } = await fetchRepoFiles(repoUrl);
+              repoInfo.branch = branch; // Set the branch for GitHub links
 
               console.log('  Files scanned: ' + files.length + (branch ? ' (branch: ' + branch + ')' : ''));
               files.forEach(f => console.log('    - ' + f.path));
@@ -394,7 +426,7 @@ jobs:
                 };
               }
 
-              const patternResults = runPatternChecks(files);
+              const patternResults = runPatternChecks(files, repoInfo);
               const aiResults = await runAISecurityCheck(files, toolName);
 
               if (aiResults?.findings?.length > 0) {


### PR DESCRIPTION
Security check results now include clickable markdown links to the
specific lines of code in the GitHub repository. The reason field
now formats line numbers as `[lines: X, Y](https://github.com/...)`,
allowing users to directly navigate to the flagged code.

Changes:
- Add generateGitHubLink helper to generate GitHub blob URLs with line anchors
- Update runPatternChecks to accept repoInfo (owner, repo, branch)
- Store githubLink in check results for potential future use