### PR TITLE
Onboard Maintainer for automated issue triage

### DIFF
--- a/.github/maintainer.yml
+++ b/.github/maintainer.yml
@@ -1,0 +1,35 @@
+# Maintainer config for AwesomeIntune
+
+triage:
+  enabled: true
+  auto_label: true
+  auto_dedupe: true
+
+fix:
+  enabled: true
+  # Conservative initial setting: triage runs automatically, but fix
+  # PRs only happen when explicitly invoked via /maintainer fix.
+  # Flip to true once a few rounds land cleanly.
+  auto_attempt: false
+  # Sonnet is plenty for a focused TS/Next.js codebase. Switch to
+  # claude-opus-4-7 if quality drops on more complex fixes.
+  model: claude-sonnet-4-6
+  # The project's check script lints and typechecks, which is the
+  # right gate for "did the agent introduce a regression" since
+  # there is no test suite.
+  test_command: "npm run check"
+
+review:
+  enabled: true
+  model: claude-sonnet-4-6
+  block_on_reject: true
+
+commands:
+  enabled: true
+  require_write_permission: true
+
+stale:
+  enabled: true
+  days_until_stale: 90
+  days_until_close: 14
+  exempt_labels: [pinned, security, enhancement]

--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -1,0 +1,28 @@
+name: Maintainer
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  maintain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ugurkocde/Maintainer@v2
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.MAINTAINER_APP_ID }}
+          app-private-key: ${{ secrets.MAINTAINER_APP_PRIVATE_KEY }}
+          supabase-url: ${{ secrets.MAINTAINER_SUPABASE_URL }}
+          supabase-secret-key: ${{ secrets.MAINTAINER_SUPABASE_SECRET_KEY }}


### PR DESCRIPTION
## Summary

Adds the [Maintainer](https://github.com/ugurkocde/Maintainer) GitHub Action so issues opened on this repo get triaged automatically and slash/mention commands work.

- **Triage runs automatically** on every new and edited issue.
- \`/maintainer fix\`, \`@maintainer ...\`, and friends are available in comments.
- **Auto-fix is disabled** for now; explicit invocation only.
- The **Reviewer specialist** is on with \`block_on_reject\` so any agent fix that goes off-script never lands as a draft PR.
- Test gate is \`npm run check\` (lint + typecheck).
- Telemetry streams to the Maintainer Supabase project; runs land on [maintainer.ugurlabs.com](https://maintainer.ugurlabs.com).

## Required before merging

Two secrets remain to be set on this repo. The other three (\`MAINTAINER_APP_ID\`, \`MAINTAINER_APP_PRIVATE_KEY\`, \`MAINTAINER_SUPABASE_URL\`) are already in place.

\`\`\`bash
# 1. Anthropic API key — same value used in your other Maintainer-installed repos
gh secret set ANTHROPIC_API_KEY --repo ugurkocde/AwesomeIntune

# 2. Service-role key for the Maintainer Supabase project
#    (https://supabase.com/dashboard/project/gpnsaswidreusgkyemvi/settings/api-keys)
gh secret set MAINTAINER_SUPABASE_SECRET_KEY --repo ugurkocde/AwesomeIntune
\`\`\`

Both prompt for the value on stdin, so nothing leaks into the shell history.

## Notes on naming

The \`MAINTAINER_\` prefix on the Supabase secrets is intentional. This repo already has its own \`SUPABASE_URL\` and \`SUPABASE_SERVICE_ROLE_KEY\` for AwesomeIntune's database; we don't want to clobber them.

## Test plan

- [ ] Set the two remaining secrets above.
- [ ] Merge this PR.
- [ ] Open a small test issue and confirm a triage comment lands within 60 seconds, authored as Maintainer with the App's logo.
- [ ] After a couple of clean runs, flip \`fix.auto_attempt\` to \`true\` in \`.github/maintainer.yml\` to enable the auto-fix path.