### PR TITLE
Parse issue form submissions in the approval workflow

### DIFF
--- a/.github/workflows/approve-tool-submission.yml
+++ b/.github/workflows/approve-tool-submission.yml
@@ -288,6 +288,25 @@ jobs:
               if (mapping[label] && value && !ignoredValues.includes(value.toLowerCase())) fields[mapping[label]] = value;
             }
 
+            // Fallback: parse GitHub issue form template format: ### Label\n\nValue
+            // (issues opened via .github/ISSUE_TEMPLATE/tool-submission.yml)
+            const formFieldMapping = {
+              'tool name': 'name', 'description': 'description', 'author name': 'author',
+              'repository url': 'repoUrl', 'category': 'category', 'type': 'type',
+              'author url (optional)': 'githubUrl', 'download url (optional)': 'downloadUrl',
+              'website url (optional)': 'websiteUrl'
+            };
+            const formPattern = /### ([^\n]+)\n\n([\s\S]*?)(?=\n### |\n---|\s*$)/g;
+            while ((match = formPattern.exec(body)) !== null) {
+              const label = match[1].trim().toLowerCase();
+              const value = match[2].trim();
+              const mapped = formFieldMapping[label];
+              const ignoredValues = ['not provided', 'n/a', 'none', '-', '', '_no response_'];
+              if (mapped && value && !ignoredValues.includes(value.toLowerCase()) && !fields[mapped]) {
+                fields[mapped] = value;
+              }
+            }
+
             // Parse multi-author format from website submissions: #### Author N: Name
             const authorSectionMatch = body.match(/### Authors\s*([\s\S]*?)(?=\n### [^#]|$)/);
             if (authorSectionMatch) {


### PR DESCRIPTION
## Summary

Tools submitted directly through the GitHub issue form template (.github/ISSUE_TEMPLATE/tool-submission.yml) were failing validation in the approval workflow: issue forms render fields as headings (### Tool Name followed by the value), but the workflow only parsed the website submission format (- **Label:** value).

This adds the heading format as a fallback parser:
- Maps the exact labels from the issue form template (Tool Name, Description, Author Name, Repository URL, Category, Type, and the optional URL fields)
- Skips GitHub's _No response_ placeholder and other empty markers
- Website-format fields keep precedence; the fallback only fills fields that are still missing

Ports the unlanded commit 931a45c from the claude/fix-github-action-Af94g branch onto the current workflow (the original predates the security-scan refactor and no longer applies cleanly). Once this merges, that stale branch can be deleted.

## Verification
- YAML validated
- Parsing logic verified against the actual field labels in .github/ISSUE_TEMPLATE/tool-submission.yml