### PR TITLE
Update MacPPPC submission handling

### DIFF
--- a/.github/workflows/approve-tool-submission.yml
+++ b/.github/workflows/approve-tool-submission.yml
@@ -184,6 +184,16 @@ jobs:
               try { new URL(str); return true; } catch { return false; }
             }
 
+            function isGitHubRepoUrl(str) {
+              try {
+                const url = new URL(str);
+                const parts = url.pathname.split('/').filter(Boolean);
+                return ['github.com', 'www.github.com'].includes(url.hostname.toLowerCase()) && parts.length >= 2;
+              } catch {
+                return false;
+              }
+            }
+
             function extractRepoName(repoUrl) {
               const match = repoUrl.match(/github\.com\/[^/]+\/([^/]+)/);
               if (!match) return null;
@@ -413,8 +423,11 @@ jobs:
 
             // STEP 3: Create catalog entry
 
-            const readmeContent = fields.repoUrl ? await fetchReadme(fields.repoUrl, securityResults.branch) : null;
-            const websiteContent = fields.websiteUrl ? await fetchWebsite(fields.websiteUrl) : null;
+            const hasGitHubRepo = isGitHubRepoUrl(fields.repoUrl);
+            const catalogRepoUrl = hasGitHubRepo ? fields.repoUrl : '';
+            const catalogWebsiteUrl = fields.websiteUrl || (!hasGitHubRepo ? fields.repoUrl : '');
+            const readmeContent = hasGitHubRepo ? await fetchReadme(fields.repoUrl, securityResults.branch) : null;
+            const websiteContent = catalogWebsiteUrl ? await fetchWebsite(catalogWebsiteUrl) : null;
 
             let enhancedDescription = fields.description;
             let keywords = [];
@@ -435,9 +448,9 @@ jobs:
               githubUrl: fields.githubUrl || '',
               linkedinUrl: fields.linkedinUrl || '',
               xUrl: fields.xUrl || '',
-              repoUrl: fields.repoUrl,
+              repoUrl: catalogRepoUrl,
               downloadUrl: fields.downloadUrl || '',
-              websiteUrl: fields.websiteUrl || '',
+              websiteUrl: catalogWebsiteUrl,
               category: normalizeCategory(fields.category),
               type: normalizeType(fields.type),
               dateAdded: today,

--- a/data/tools/pppc-builder-for-macos.json
+++ b/data/tools/pppc-builder-for-macos.json
@@ -1,7 +1,7 @@
 {
   "id": "pppc-builder-for-macos",
-  "name": "PPPC Builder for macOS",
-  "description": "PPPC Builder for macOS is a lightweight web-based tool that generates macOS PPPC (.mobileconfig) profiles tailored for Microsoft Intune deployments. You can select an app (or upload its Info.plist), choose required privacy permissions (Screen Recording, Full Disk Access, Camera, Microphone, Accessibility), and download a ready-to-deploy .mobileconfig for Intune. No Jamf dependency; simple, fast, Intune-focused.",
+  "name": "MacPPPC",
+  "description": "MacPPPC is a browser-based builder for macOS Privacy Preferences Policy Control profiles. It generates unsigned .mobileconfig or Settings Catalog JSON output and can deploy profiles, scope tags, and assignments directly to Microsoft Intune through delegated Microsoft Graph access.",
   "keywords": [
     "intune",
     "macos",
@@ -9,22 +9,26 @@
     "privacy",
     "mobileconfig",
     "configuration-profile",
-    "web-based",
+    "settings-catalog",
+    "microsoft-graph",
+    "scope-tags",
+    "assignments",
     "deployment"
   ],
-  "author": "Simon Hartmann Eriksen",
-  "authorPicture": "",
-  "githubUrl": "",
-  "linkedinUrl": "https://www.linkedin.com/in/simoneriksendk/",
-  "xUrl": "https://x.com/Sim0nEriksen",
+  "author": "Roy Klooster",
+  "authorPicture": "https://github.com/royklo.png",
+  "githubUrl": "https://github.com/royklo",
+  "linkedinUrl": "https://www.linkedin.com/in/roy-klooster/",
+  "xUrl": "",
   "repoUrl": "https://github.com/Simsen/PPPC-Builder",
   "downloadUrl": "",
-  "websiteUrl": "",
+  "websiteUrl": "https://macpppc.com",
   "category": "configuration",
   "type": "web-app",
   "worksWith": [
     "macos",
-    "configuration-profiles"
+    "configuration-profiles",
+    "entra-id"
   ],
   "dateAdded": "2026-02-23",
   "securityCheck": {
@@ -66,7 +70,15 @@
   },
   "authors": [
     {
+      "name": "Roy Klooster",
+      "githubUrl": "https://github.com/royklo",
+      "picture": "https://github.com/royklo.png",
+      "linkedinUrl": "https://www.linkedin.com/in/roy-klooster/"
+    },
+    {
       "name": "Simon Hartmann Eriksen",
+      "githubUrl": "https://github.com/Simsen",
+      "picture": "https://github.com/Simsen.png",
       "linkedinUrl": "https://www.linkedin.com/in/simoneriksendk/",
       "xUrl": "https://x.com/Sim0nEriksen"
     }


### PR DESCRIPTION
## What changed

- updates the existing PPPC Builder catalog entry to MacPPPC while preserving its stable ID, repository statistics, and security history
- adds Roy Klooster and Simon Hartmann Eriksen as authors
- adds the live MacPPPC website and current Intune deployment capabilities
- stores non-GitHub submission URLs as website links instead of incorrectly treating them as source repositories
- uses a web-only submission URL as website context during catalog generation

## Why

MacPPPC is an evolution of an existing cataloged tool, so it should update that entry rather than create a duplicate. CMTrace Web is a web-only submission and needs to be cataloged as a website without a false source-code badge.

## Validation

- `npm run check` (0 errors, 2 existing configuration warnings)
- `npm run build`
- workflow YAML parse
- JSON parse
- `git diff --check`