### PR TITLE
Add MacPPPC public slug

### DIFF
--- a/data/tools/pppc-builder-for-macos.json
+++ b/data/tools/pppc-builder-for-macos.json
@@ -1,5 +1,6 @@
 {
   "id": "pppc-builder-for-macos",
+  "slug": "macpppc",
   "name": "MacPPPC",
   "description": "MacPPPC is a browser-based builder for macOS Privacy Preferences Policy Control profiles. It generates unsigned .mobileconfig or Settings Catalog JSON output and can deploy profiles, scope tags, and assignments directly to Microsoft Intune through delegated Microsoft Graph access.",
   "keywords": [

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,11 @@ const config = {
         destination: "/",
         permanent: true,
       },
+      {
+        source: "/tools/pppc-builder-for-macos",
+        destination: "/tools/macpppc",
+        permanent: true,
+      },
     ];
   },
   async headers() {

--- a/src/app/best/[category]/page.tsx
+++ b/src/app/best/[category]/page.tsx
@@ -9,6 +9,7 @@ import {
   BEST_TYPE_SLUGS,
 } from "~/lib/best-categories";
 import type { ToolCategory } from "~/types/tool";
+import { getToolSlug } from "~/lib/tools";
 
 // Labels for the type-based PowerShell pages
 const TYPE_PAGE_LABELS: Record<string, string> = {
@@ -175,7 +176,7 @@ export default async function BestCategoryPage({ params }: BestCategoryPageProps
         "@type": "SoftwareApplication",
         name: tool.name,
         description: tool.description,
-        url: `${SITE_CONFIG.url}/tools/${tool.id}`,
+        url: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}`,
         applicationCategory: categoryConfig?.label ?? "Utility",
         ...(tool.repoStats?.stars && {
           aggregateRating: {
@@ -348,7 +349,7 @@ export default async function BestCategoryPage({ params }: BestCategoryPageProps
               return (
                 <Link
                   key={tool.id}
-                  href={`/tools/${tool.id}`}
+                  href={`/tools/${getToolSlug(tool)}`}
                   className="group block rounded-2xl transition-all hover:scale-[1.01]"
                   style={{
                     background: "var(--bg-secondary)",

--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -7,7 +7,7 @@ import {
   getAllCollectionSlugs,
   getCollectionTools,
 } from "~/lib/tools.server";
-import { getToolAuthors } from "~/lib/tools";
+import { getToolAuthors, getToolSlug } from "~/lib/tools";
 import {
   SITE_CONFIG,
   TYPE_CONFIG,
@@ -286,7 +286,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
         "@type": "SoftwareApplication",
         name: tool.name,
         description: tool.description,
-        url: `${SITE_CONFIG.url}/tools/${tool.id}`,
+        url: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}`,
         applicationCategory:
           CATEGORY_CONFIG[tool.category]?.label ?? tool.category,
         offers: {
@@ -473,7 +473,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
                     return (
                       <Link
                         key={tool.id}
-                        href={`/tools/${tool.id}`}
+                        href={`/tools/${getToolSlug(tool)}`}
                         className="group relative overflow-hidden rounded-xl transition-all duration-300 hover:scale-[1.02]"
                         style={{
                           background: "var(--bg-tertiary)",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
   getCollectionTools,
 } from "~/lib/tools.server";
 import { SITE_CONFIG, STATIC_PAGES_LAST_MODIFIED } from "~/lib/constants";
+import { getToolSlug } from "~/lib/tools";
 import type { Tool, ToolCategory, ToolType } from "~/types/tool";
 
 // Map categories to best-of URL slugs
@@ -99,7 +100,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   // Tool detail pages
   const toolPages: MetadataRoute.Sitemap = tools.map((tool) => ({
-    url: `${baseUrl}/tools/${tool.id}`,
+    url: `${baseUrl}/tools/${getToolSlug(tool)}`,
     lastModified: new Date(tool.dateAdded),
     changeFrequency: "weekly" as const,
     priority: 0.8,

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getAllTools, getAllCategories, getUniqueAuthorsCount } from "~/lib/tools.server";
-import { isVerified } from "~/lib/tools";
+import { getToolSlug, isVerified } from "~/lib/tools";
 import { CATEGORY_CONFIG, TYPE_CONFIG, SITE_CONFIG } from "~/lib/constants";
 import { generateStatsPageStructuredData, generateDataCatalogStructuredData } from "~/lib/structured-data";
 import type { ToolCategory, ToolType } from "~/types/tool";
@@ -291,7 +291,7 @@ export default function StatsPage() {
                   {topByStars.map((tool, index) => (
                     <Link
                       key={tool.id}
-                      href={`/tools/${tool.id}`}
+                      href={`/tools/${getToolSlug(tool)}`}
                       className="group flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-white/5"
                     >
                       <span
@@ -343,7 +343,7 @@ export default function StatsPage() {
                   {newestTools.map((tool) => (
                     <Link
                       key={tool.id}
-                      href={`/tools/${tool.id}`}
+                      href={`/tools/${getToolSlug(tool)}`}
                       className="group flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-white/5"
                     >
                       <span

--- a/src/app/tools/[id]/page.tsx
+++ b/src/app/tools/[id]/page.tsx
@@ -3,11 +3,11 @@ import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
 import {
-  getToolById,
-  getAllToolIds,
+  getToolBySlug,
+  getAllToolSlugs,
   getRelatedTools,
 } from "~/lib/tools.server";
-import { getToolAuthors, generateAuthorSlug } from "~/lib/tools";
+import { getToolAuthors, generateAuthorSlug, getToolSlug } from "~/lib/tools";
 import { TYPE_CONFIG, CATEGORY_CONFIG, SITE_CONFIG } from "~/lib/constants";
 import {
   generateToolStructuredData,
@@ -34,15 +34,15 @@ interface ToolPageProps {
 }
 
 export async function generateStaticParams() {
-  const toolIds = getAllToolIds();
-  return toolIds.map((id) => ({ id }));
+  const toolSlugs = getAllToolSlugs();
+  return toolSlugs.map((id) => ({ id }));
 }
 
 export async function generateMetadata({
   params,
 }: ToolPageProps): Promise<Metadata> {
   const { id } = await params;
-  const tool = getToolById(id);
+  const tool = getToolBySlug(id);
 
   if (!tool) {
     return {
@@ -81,13 +81,13 @@ export async function generateMetadata({
     description,
     keywords,
     alternates: {
-      canonical: `${SITE_CONFIG.url}/tools/${tool.id}`,
+      canonical: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}`,
     },
     openGraph: {
       title,
       description,
       type: "website",
-      url: `${SITE_CONFIG.url}/tools/${tool.id}`,
+      url: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}`,
       images: [
         {
           url: ogImageUrl,
@@ -172,7 +172,7 @@ function TypeIcon({ type }: { type: string }) {
 
 export default async function ToolPage({ params }: ToolPageProps) {
   const { id } = await params;
-  const tool = getToolById(id);
+  const tool = getToolBySlug(id);
 
   if (!tool) {
     notFound();
@@ -194,7 +194,7 @@ export default async function ToolPage({ params }: ToolPageProps) {
       name: categoryConfig.label,
       url: `${SITE_CONFIG.url}/tools/category/${tool.category}`,
     },
-    { name: tool.name, url: `${SITE_CONFIG.url}/tools/${tool.id}` },
+    { name: tool.name, url: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}` },
   ]);
   const faqData = generateToolFAQStructuredData(tool);
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -15,7 +15,7 @@ import { SponsorStrip } from "./SponsorStrip";
 import { SearchBar } from "./tools/SearchBar";
 import { shouldUseAiSearch } from "~/lib/aiSearch";
 import { CATEGORY_CONFIG, TYPE_CONFIG } from "~/lib/constants";
-import { isVerified } from "~/lib/tools";
+import { getToolSlug, isVerified } from "~/lib/tools";
 import type { Tool, ToolCategory } from "~/types/tool";
 
 interface HeroProps {
@@ -212,7 +212,7 @@ export function Hero({
             {newestTools.map((tool) => (
               <Link
                 key={tool.id}
-                href={`/tools/${tool.id}`}
+                href={`/tools/${getToolSlug(tool)}`}
                 className="flex items-center gap-3 rounded-xl px-4 py-3 transition-colors hover:bg-slate-100"
               >
                 <span className="font-display flex h-[34px] w-[34px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-100 text-sm font-bold text-[var(--accent-primary)]">

--- a/src/components/authors/AuthorPageClient.tsx
+++ b/src/components/authors/AuthorPageClient.tsx
@@ -6,6 +6,7 @@ import type { Tool } from "~/types/tool";
 import type { ViewCounts } from "~/hooks/useViewTracking";
 import { formatViewCount } from "~/hooks/useViewTracking";
 import { TYPE_CONFIG, CATEGORY_CONFIG } from "~/lib/constants";
+import { getToolSlug } from "~/lib/tools";
 
 interface AuthorPageClientProps {
   tools: Tool[];
@@ -380,7 +381,7 @@ function ToolCard({
 
   return (
     <Link
-      href={`/tools/${tool.id}`}
+      href={`/tools/${getToolSlug(tool)}`}
       className="group relative overflow-hidden rounded-xl transition-all duration-300 hover:scale-[1.02] hover:shadow-lg"
       style={{
         background: "var(--bg-tertiary)",

--- a/src/components/tools/RelatedTools.tsx
+++ b/src/components/tools/RelatedTools.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import type { Tool } from "~/types/tool";
 import { TYPE_CONFIG, CATEGORY_CONFIG } from "~/lib/constants";
-import { getToolAuthors } from "~/lib/tools";
+import { getToolAuthors, getToolSlug } from "~/lib/tools";
 
 interface RelatedToolsProps {
   tools: Tool[];
@@ -54,7 +54,7 @@ export function RelatedTools({ tools, currentToolId }: RelatedToolsProps) {
           return (
             <Link
               key={tool.id}
-              href={`/tools/${tool.id}`}
+              href={`/tools/${getToolSlug(tool)}`}
               className="group relative overflow-hidden rounded-2xl border border-[color:var(--border-subtle)] transition-all duration-300 hover:-translate-y-1 hover:border-[color:var(--border-accent)]"
               style={{
                 background: "var(--bg-secondary)",

--- a/src/components/tools/ToolCard.tsx
+++ b/src/components/tools/ToolCard.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import type { Tool } from "~/types/tool";
 import { TYPE_CONFIG, CATEGORY_CONFIG } from "~/lib/constants";
 import { trackToolClick, trackOutboundLink } from "~/lib/plausible";
-import { getToolAuthors, generateAuthorSlug } from "~/lib/tools";
+import { getToolAuthors, generateAuthorSlug, getToolSlug } from "~/lib/tools";
 import { formatViewCount } from "~/hooks/useViewTracking";
 import { UpvoteButton } from "./UpvoteButton";
 import { SecurityBadge } from "./SecurityBadge";
@@ -427,7 +427,7 @@ export const ToolCard = memo(function ToolCard({
             >
               {/* View Details Link - stretched to make the whole card clickable */}
               <Link
-                href={`/tools/${tool.id}`}
+                href={`/tools/${getToolSlug(tool)}`}
                 onClick={handleDetailsClick}
                 className="flex flex-1 items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-medium transition-[background-color,color] hover:bg-slate-200 hover:text-[var(--text-primary)]"
                 style={{

--- a/src/components/tools/ToolListItem.tsx
+++ b/src/components/tools/ToolListItem.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import type { Tool } from "~/types/tool";
 import { TYPE_CONFIG, CATEGORY_CONFIG } from "~/lib/constants";
 import { trackToolClick, trackOutboundLink } from "~/lib/plausible";
-import { getToolAuthors } from "~/lib/tools";
+import { getToolAuthors, getToolSlug } from "~/lib/tools";
 import { formatViewCount } from "~/hooks/useViewTracking";
 import { UpvoteButton } from "./UpvoteButton";
 
@@ -260,7 +260,7 @@ export const ToolListItem = memo(function ToolListItem({
           <div className="flex items-center justify-end gap-2">
             {/* Stretched primary link makes the whole row navigable */}
             <Link
-              href={`/tools/${tool.id}`}
+              href={`/tools/${getToolSlug(tool)}`}
               onClick={handleViewClick}
               className="flex h-8 items-center gap-1.5 rounded-lg px-3 text-xs font-medium transition-colors hover:bg-white/10"
               style={{

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -4,7 +4,7 @@ import {
   CATEGORY_CONFIG,
   STATIC_PAGES_LAST_MODIFIED,
 } from "./constants";
-import { getToolAuthors } from "./tools";
+import { getToolAuthors, getToolSlug } from "./tools";
 
 /**
  * Generate JSON-LD structured data for a tool (SoftwareApplication schema)
@@ -193,7 +193,7 @@ export function generateItemListStructuredData(tools: Tool[]) {
         "@type": "SoftwareApplication",
         name: tool.name,
         description: tool.description,
-        url: `${SITE_CONFIG.url}/tools/${tool.id}`,
+        url: `${SITE_CONFIG.url}/tools/${getToolSlug(tool)}`,
         applicationCategory:
           CATEGORY_CONFIG[tool.category]?.label ?? tool.category,
         offers: {

--- a/src/lib/tools.server.ts
+++ b/src/lib/tools.server.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import type { Tool, Author } from "~/types/tool";
 import type { Collection } from "~/types/collection";
-import { getToolAuthors, generateAuthorSlug } from "./tools";
+import { getToolAuthors, generateAuthorSlug, getToolSlug } from "./tools";
 
 export interface AuthorWithTools extends Author {
   slug: string;
@@ -64,6 +64,14 @@ export function getToolById(id: string): Tool | undefined {
 }
 
 /**
+ * Get a tool by its public URL slug.
+ */
+export function getToolBySlug(slug: string): Tool | undefined {
+  const tools = getAllTools();
+  return tools.find((tool) => getToolSlug(tool) === slug);
+}
+
+/**
  * Get all tools in a specific category
  */
 export function getToolsByCategory(category: string): Tool[] {
@@ -77,6 +85,14 @@ export function getToolsByCategory(category: string): Tool[] {
 export function getAllToolIds(): string[] {
   const tools = getAllTools();
   return tools.map((tool) => tool.id);
+}
+
+/**
+ * Get all public tool slugs (for static generation).
+ */
+export function getAllToolSlugs(): string[] {
+  const tools = getAllTools();
+  return tools.map(getToolSlug);
 }
 
 /**

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,6 +1,13 @@
 import type { Author, Tool, ToolCategory, ToolType } from "~/types/tool";
 
 /**
+ * Get the public URL slug for a tool while keeping its internal ID stable.
+ */
+export function getToolSlug(tool: Tool): string {
+  return tool.slug ?? tool.id;
+}
+
+/**
  * Whether a tool's source genuinely passed every automated security check.
  *
  * Single source of truth for the "verified" count (trust strip, stats). Honest

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -113,6 +113,8 @@ export interface RepoStats {
 
 export interface Tool {
   id: string;
+  /** Optional public URL slug when it should differ from the stable internal ID. */
+  slug?: string;
   name: string;
   description: string;
   keywords?: string[];


### PR DESCRIPTION
## What changed

- Added an optional public slug for catalog tools while preserving their stable internal IDs.
- Assigned MacPPPC the public slug `/tools/macpppc`.
- Updated tool links, canonical metadata, Open Graph metadata, structured data, and sitemap output to use public slugs.
- Added a permanent redirect from `/tools/pppc-builder-for-macos` to `/tools/macpppc`.

## Why

The catalog entry was renamed from PPPC Builder for macOS to MacPPPC, but its public URL still reflected the old name. Separating the public slug from the internal ID provides a consistent URL without losing existing votes, views, API references, or screenshot paths.

## Validation

- `npm run check`
- `npm run build`
- Verified the generated route is `/tools/macpppc`.
- Verified the old URL produces a permanent 308 redirect.
- Verified canonical, Open Graph, breadcrumb, and sitemap URLs use `/tools/macpppc`.
