### PR TITLE
Keep workflow dependency installs clean

### DIFF
--- a/.github/workflows/approve-tool-submission.yml
+++ b/.github/workflows/approve-tool-submission.yml
@@ -42,7 +42,9 @@ jobs:
           node-version: '20'
 
       - name: Install OpenAI SDK
-        run: npm install openai
+        # Keep tracked dependency files untouched so a rejected concurrent push
+        # can rebase and retry cleanly in the commit step below.
+        run: npm install --no-save --package-lock=false openai
 
       - name: Process tool submission
         id: process

--- a/.github/workflows/backfill-security-scans.yml
+++ b/.github/workflows/backfill-security-scans.yml
@@ -35,7 +35,9 @@ jobs:
           node-version: '20'
 
       - name: Install OpenAI SDK
-        run: npm install openai
+        # Keep tracked dependency files untouched so a rejected concurrent push
+        # can rebase and retry cleanly in the commit step below.
+        run: npm install --no-save --package-lock=false openai
 
       - name: Run security backfill
         id: backfill


### PR DESCRIPTION
## What changed

- install the OpenAI SDK without updating `package.json` or `package-lock.json` in the tool-approval workflow
- apply the same clean install behavior to the scheduled security backfill workflow

## Why

Concurrent tool approvals can race while pushing generated catalog entries to `main`. The workflow is designed to fetch, rebase, and retry, but `npm install openai` modifies `package-lock.json`. That unstaged change makes `git rebase` abort before the retry.

Using `--no-save --package-lock=false` keeps tracked dependency files clean, allowing the existing rebase-and-retry logic to work as intended.

## Validation

- ran the replacement install command successfully
- confirmed `package.json` and `package-lock.json` have no diff
- ran `git diff --check`
